### PR TITLE
fix: add lodash to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
+        "lodash": "^4.17.21",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -17341,8 +17342,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -38418,8 +38418,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "webpack": "^5.75.0"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "zxcvbn": "^4.4.2"
   }
 }


### PR DESCRIPTION
Lodash is a direct application import and should be stated in dependencies. Otherwise this results in it being a phantom dep. that isn't being included when using the package as a third party.
<img width="973" alt="lodash" src="https://github.com/justinmahar/silly-password-generator/assets/2671660/dba2156b-6785-4241-914e-6744358ccc19">
